### PR TITLE
Fix code scanning alert no. 11: Missing CSRF middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dapp-backend",
-  "version": "0.201.12",
+  "version": "0.201.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dapp-backend",
-      "version": "0.201.12",
+      "version": "0.201.17",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.617.0",
@@ -15,6 +15,7 @@
         "@hashgraph/sdk": "^2.30.0",
         "@prisma/adapter-pg": "^6.0.0",
         "@prisma/client": "^6.0.0",
+        "@types/lusca": "^1.7.5",
         "@types/pg": "^8.11.10",
         "axios": "^1.6.7",
         "bignumber.js": "^9.1.2",
@@ -36,6 +37,7 @@
         "jsdoc-to-markdown": "^8.0.0",
         "json-bigint": "^1.0.0",
         "lodash": "^4.17.21",
+        "lusca": "^1.7.0",
         "markdown-it": "^13.0.1",
         "module-alias": "^2.2.2",
         "moment": "^2.29.4",
@@ -3407,7 +3409,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3434,7 +3435,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3461,7 +3461,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3473,7 +3472,6 @@
       "version": "4.19.0",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz",
       "integrity": "sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3524,8 +3522,7 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/http-status-codes": {
       "version": "1.2.0",
@@ -3576,6 +3573,15 @@
       "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==",
       "dev": true
     },
+    "node_modules/@types/lusca": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/lusca/-/lusca-1.7.5.tgz",
+      "integrity": "sha512-l49gAf8pu2iMzbKejLcz6Pqj+51H2na6BgORv1ElnE8ByPFcBdh/eZ0WNR1Va/6ZuNSZa01Hoy1DTZ3IZ+y+kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -3593,8 +3599,7 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/module-alias": {
       "version": "2.0.4",
@@ -3752,14 +3757,12 @@
     "node_modules/@types/qs": {
       "version": "6.9.15",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "dev": true
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
@@ -3787,7 +3790,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -3797,7 +3799,6 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*",
@@ -9091,6 +9092,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
@@ -13032,6 +13044,15 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     "twit": "^2.2.11",
     "twitter-api-v2": "^1.12.3",
     "web3": "^1.7.5",
-    "ws": "^7.5.10"
+    "ws": "^7.5.10",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@openzeppelin/contracts": "^4.9.3",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@hashgraph/sdk": "^2.30.0",
     "@prisma/adapter-pg": "^6.0.0",
     "@prisma/client": "^6.0.0",
+    "@types/lusca": "^1.7.5",
     "@types/pg": "^8.11.10",
     "axios": "^1.6.7",
     "bignumber.js": "^9.1.2",
@@ -126,6 +127,7 @@
     "jsdoc-to-markdown": "^8.0.0",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
+    "lusca": "^1.7.0",
     "markdown-it": "^13.0.1",
     "module-alias": "^2.2.2",
     "moment": "^2.29.4",
@@ -146,8 +148,7 @@
     "twit": "^2.2.11",
     "twitter-api-v2": "^1.12.3",
     "web3": "^1.7.5",
-    "ws": "^7.5.10",
-    "lusca": "^1.7.0"
+    "ws": "^7.5.10"
   },
   "devDependencies": {
     "@openzeppelin/contracts": "^4.9.3",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -41,7 +41,7 @@ const initializeApp = async () => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use(cookieParser());
-  app.use(session({ secret: process.env['SECRET'], cookie: { maxAge: 60000 } }));
+  app.use(session({ secret: config.encryptions.sessionSecreat, cookie: { maxAge: 60000 } }));
   app.use(lusca.csrf());
   app.use(responseFormatter);
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import express, { NextFunction, Request, Response } from "express";
 import "express-async-errors";
 import rateLimit from "express-rate-limit";
 import session from "express-session";
+import lusca from "lusca";
 import fs from 'fs';
 import helmet from "helmet";
 import { isHttpError } from "http-errors";
@@ -40,6 +41,8 @@ const initializeApp = async () => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use(cookieParser());
+  app.use(session({ secret: process.env['SECRET'], cookie: { maxAge: 60000 } }));
+  app.use(lusca.csrf());
   app.use(responseFormatter);
 
   if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
Fixes [https://github.com/Hashbuzz-Social/dApp-backend/security/code-scanning/11](https://github.com/Hashbuzz-Social/dApp-backend/security/code-scanning/11)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides CSRF protection and can be easily integrated into the existing middleware setup.

1. Install the `lusca` package.
2. Import the `lusca` package in the `src/server/index.ts` file.
3. Add the `lusca.csrf()` middleware to the Express application after the session middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
